### PR TITLE
replace: deprecated --verbose flag with --logLevel

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
       - name: Build
-        run: hugo --verbose --printMemoryUsage --printI18nWarnings --printUnusedTemplates --source ./frontend
+        run: hugo --logLevel debug --printMemoryUsage --printI18nWarnings --printUnusedTemplates --source ./frontend


### PR DESCRIPTION
The `--verbose` flag has been deprecated. Use `--logLevel debug` in the CI frontend job.