### PR TITLE
add: difficulty and log2_work metrics for blocks

### DIFF
--- a/backend/migrations/2025-04-04-000000_mining-difficulty/down.sql
+++ b/backend/migrations/2025-04-04-000000_mining-difficulty/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE block_stats
+  DROP COLUMN difficulty;
+
+ALTER TABLE block_stats
+  DROP COLUMN log2_work;

--- a/backend/migrations/2025-04-04-000000_mining-difficulty/up.sql
+++ b/backend/migrations/2025-04-04-000000_mining-difficulty/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE block_stats
+  ADD COLUMN difficulty BIGINT NOT NULL DEFAULT (0);
+
+ALTER TABLE block_stats
+  ADD COLUMN log2_work REAL NOT NULL DEFAULT (0);

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -22,6 +22,8 @@ diesel::table! {
         inputs -> Integer,
         outputs -> Integer,
         pool_id -> Integer,
+        difficulty -> BigInt,
+        log2_work -> Float,
     }
 }
 


### PR DESCRIPTION
Addresses the backend part of #29. The hashrate can be calculated in the frontend. Cumulative work possibly too. 