### PR TITLE
update: rawtx-rs 0.1.17 -> 0.1.19 to fix two bugs

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "rawtx-rs"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e76cafbd936a365f8292f653e599e4f0dd40a7e8d933a028d1b77084da7400ec"
+checksum = "bf06cf63043e7011708d4369f4af7abd9eecbfc811bdbf180acc511a0d52a864"
 dependencies = [
  "bitcoin",
  "hex",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,7 +11,7 @@ serde = "1.0.188"
 diesel = { version = "= 2.1", features = ["sqlite", "64-column-tables"] }
 diesel_migrations = "2.1"
 chrono = "0.4.26"
-rawtx-rs = "0.1.17"
+rawtx-rs = "0.1.19"
 rayon = "1.7.0"
 minreq = { version = "2.12.0", features = ["json-using-serde"] }
 log = "0.4.22"


### PR DESCRIPTION
in OP_RETURN detection which would lead to crashing the stats generation due to out of bounds access on vectors...