### PR TITLE
add: UTXO set size chart

### DIFF
--- a/frontend/content/charts/utxoset-size.md
+++ b/frontend/content/charts/utxoset-size.md
@@ -1,0 +1,18 @@
+---
+title: "UTXO count"
+draft: true
+author: "0xb10c"
+categories: UTXO set
+categories_weight: 0
+tags: ["utxo", "utxoset"]
+thumbnail: utxoset-size.png
+chartJS: utxoset-size.js
+images:
+  - /img/chart-thumbnails/utxoset-size.png
+---
+
+Shows the UTXO set size over time.
+
+<!--more-->
+
+Note that this does not include OP_RETURN outputs.

--- a/frontend/static/js/charts/utxoset-size.js
+++ b/frontend/static/js/charts/utxoset-size.js
@@ -1,0 +1,34 @@
+const chartRollingAverage = 7
+
+const CSVs = [
+  d3.csv("/csv/date.csv"),
+  d3.csv("/csv/inputs_sum.csv"),
+  d3.csv("/csv/outputs_sum.csv"),
+  d3.csv("/csv/outputs_opreturn_sum.csv"),
+]
+
+function preprocess(data) {
+  let combinedData = []
+  let utxos = 0
+  for (let i = 0; i < data[0].length; i++) {
+    const date = d3.timeParse("%Y-%m-%d")(data[0][i].date)
+    utxos += parseFloat(data[2][i].outputs_sum)
+    utxos -= parseFloat(data[3][i].outputs_opreturn_sum)
+    utxos -= parseFloat(data[1][i].inputs_sum)
+    const y = utxos
+    combinedData.push({date, y})
+  }
+
+  return combinedData
+}
+
+const annotations = []
+const labels = {"y": "UTXO set size (count)"}
+const dataType = dataTypeMetric
+yAxis.tickFormat(d3.format("~s"));
+const unit = ""
+
+var yValue = (d => d.y);
+var yDomain = (data => [0, d3.max(data, d => (xScale.domain()[0] <= d.date && xScale.domain()[1] > d.date) ? yValue(d) : 0)])
+const chartFunction = lineWithAreaChart
+const startDate = d3.timeParse("%Y-%m-%d")("2017-07-01")


### PR DESCRIPTION
A step towards #14

![image](https://github.com/user-attachments/assets/f335e385-0b7d-4c9d-ab35-5f4c63ef16ce)


I've checked this against a recent `gettxoutsetinfo` and the `txouts` roughly match.