### PR TITLE
Fix: add bzip2.dev and clippy to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,11 +14,13 @@ pkgs.mkShell {
     pkgs.cargo
     pkgs.rustc
     pkgs.rustfmt
+    pkgs.clippy
     pkgs.sqlite
     pkgs.diesel-cli
 
     # for integration-tests
     pkgs.bitcoind
+    pkgs.bzip2.dev
 
     # frontend
     pkgs.hugo


### PR DESCRIPTION
On non-NixOS (e.g. `nix-shell` on macOS), building tests fails due to missing bzip2 headers:

```
   Compiling corepc-node v0.6.1
   Compiling mainnet-observer-backend v0.1.0 (/Users/deadmanoz/dev/mainnet-observer/backend)
error: linking with `cc` failed: exit status: 1
  |
....
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld: library not found for -lbz2
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          
error: could not compile `corepc-node` (build script) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

Probably NixOS users don't encounter this because bzip2 is available system-wide?

So this PR add missing dependencies for full development workflow on non-nixOS systems
- `clippy`: for `cargo clippy` linting
- `bzip2.dev`: needed to compile integration tests

P.S. I have just been using a local branch with this change (and a few others) that I merge whenever I work on other features. That is to say, this has been a problem for a while, I just have worked around it until this point!