### PR TITLE
change: use replace_into instead of insert_into

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -389,33 +389,9 @@ fn insert_block_stats(
     use crate::schema::block_stats;
     debug!("Inserting a batch of {} block stats", stats.len());
 
-    if let Err(e) = diesel::insert_into(block_stats::table)
+    diesel::replace_into(block_stats::table)
         .values(stats)
-        .execute(conn)
-    {
-        match e {
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            ) => {
-                debug!(
-                    "Falling back to individually inserting {} block stats: {}",
-                    stats.len(),
-                    e
-                );
-                for stat in stats.iter() {
-                    diesel::insert_into(block_stats::table)
-                        .values(stat)
-                        .on_conflict(block_stats::height)
-                        .do_update()
-                        .set(stat)
-                        .execute(conn)?;
-                }
-                return Ok(());
-            }
-            _ => return Err(e),
-        }
-    }
+        .execute(conn)?;
     Ok(())
 }
 
@@ -426,33 +402,9 @@ fn insert_tx_stats(
     use crate::schema::tx_stats;
     debug!("Inserting a batch of {} tx stats", stats.len());
 
-    if let Err(e) = diesel::insert_into(tx_stats::table)
+    diesel::replace_into(tx_stats::table)
         .values(stats)
-        .execute(conn)
-    {
-        match e {
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            ) => {
-                debug!(
-                    "Falling back to individually inserting {} tx stats: {}",
-                    stats.len(),
-                    e
-                );
-                for stat in stats.iter() {
-                    diesel::insert_into(tx_stats::table)
-                        .values(stat)
-                        .on_conflict(tx_stats::height)
-                        .do_update()
-                        .set(stat)
-                        .execute(conn)?;
-                }
-                return Ok(());
-            }
-            _ => return Err(e),
-        }
-    }
+        .execute(conn)?;
     Ok(())
 }
 
@@ -463,33 +415,9 @@ fn insert_input_stats(
     use crate::schema::input_stats;
     debug!("Inserting a batch of {} input stats", stats.len());
 
-    if let Err(e) = diesel::insert_into(input_stats::table)
+    diesel::insert_into(input_stats::table)
         .values(stats)
-        .execute(conn)
-    {
-        match e {
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            ) => {
-                debug!(
-                    "Falling back to individually inserting {} input stats: {}",
-                    stats.len(),
-                    e
-                );
-                for stat in stats.iter() {
-                    diesel::insert_into(input_stats::table)
-                        .values(stat)
-                        .on_conflict(input_stats::height)
-                        .do_update()
-                        .set(stat)
-                        .execute(conn)?;
-                }
-                return Ok(());
-            }
-            _ => return Err(e),
-        }
-    }
+        .execute(conn)?;
     Ok(())
 }
 
@@ -500,33 +428,9 @@ fn insert_output_stats(
     use crate::schema::output_stats;
     debug!("Inserting a batch of {} output stats", stats.len());
 
-    if let Err(e) = diesel::insert_into(output_stats::table)
+    diesel::replace_into(output_stats::table)
         .values(stats)
-        .execute(conn)
-    {
-        match e {
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            ) => {
-                debug!(
-                    "Falling back to individually inserting {} output stats: {}",
-                    stats.len(),
-                    e
-                );
-                for stat in stats.iter() {
-                    diesel::insert_into(output_stats::table)
-                        .values(stat)
-                        .on_conflict(output_stats::height)
-                        .do_update()
-                        .set(stat)
-                        .execute(conn)?;
-                }
-                return Ok(());
-            }
-            _ => return Err(e),
-        }
-    }
+        .execute(conn)?;
     Ok(())
 }
 
@@ -537,33 +441,9 @@ fn insert_script_stats(
     use crate::schema::script_stats;
     debug!("Inserting a batch of {} script stats", stats.len());
 
-    if let Err(e) = diesel::insert_into(script_stats::table)
+    diesel::replace_into(script_stats::table)
         .values(stats)
-        .execute(conn)
-    {
-        match e {
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            ) => {
-                debug!(
-                    "Falling back to individually inserting {} script stats: {}",
-                    stats.len(),
-                    e
-                );
-                for stat in stats.iter() {
-                    diesel::insert_into(script_stats::table)
-                        .values(stat)
-                        .on_conflict(script_stats::height)
-                        .do_update()
-                        .set(stat)
-                        .execute(conn)?;
-                }
-                return Ok(());
-            }
-            _ => return Err(e),
-        }
-    }
+        .execute(conn)?;
     Ok(())
 }
 
@@ -574,32 +454,8 @@ fn insert_feerate_stats(
     use crate::schema::feerate_stats;
     debug!("Inserting a batch of {} feerate stats", stats.len());
 
-    if let Err(e) = diesel::insert_into(feerate_stats::table)
+    diesel::replace_into(feerate_stats::table)
         .values(stats)
-        .execute(conn)
-    {
-        match e {
-            diesel::result::Error::DatabaseError(
-                diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            ) => {
-                debug!(
-                    "Falling back to individually inserting {} feerate stats: {}",
-                    stats.len(),
-                    e
-                );
-                for stat in stats.iter() {
-                    diesel::insert_into(feerate_stats::table)
-                        .values(stat)
-                        .on_conflict(feerate_stats::height)
-                        .do_update()
-                        .set(stat)
-                        .execute(conn)?;
-                }
-                return Ok(());
-            }
-            _ => return Err(e),
-        }
-    }
+        .execute(conn)?;
     Ok(())
 }


### PR DESCRIPTION
Since #113, we are running into UNIQUE CONSTRAINT conflicts on each stats_version updated. Previously, we'd fall back to upserting each height in each table separatly. This had a few problems:

1. It's slower than just deleting and inserting the stats for that height.
2. It's more code and logic to maintain.
3. And most importantly, there seems to be a memory leak when doing so. It just wasn't discovered before, as these manual upserts were rare.

Using SQLite's REPLACE (i.e. INSERT OR REPLACE) is an improvement on all of the above points.

fixes https://github.com/0xB10C/mainnet-observer/issues/117