### PR TITLE
fix(backend): create CSV directory if it doesn't exist

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -334,6 +334,7 @@ pub fn write_csv_files(
     csv_path: &str,
     connection: Arc<Mutex<SqliteConnection>>,
 ) -> Result<(), MainError> {
+    std::fs::create_dir_all(csv_path)?;
     gen_csv::date_csv(csv_path, connection.clone())?;
     gen_csv::metrics_csv(csv_path, connection.clone())?;
     gen_csv::top5_miningpools_csv(csv_path, connection.clone())?;


### PR DESCRIPTION
## Summary

Calls `std::fs::create_dir_all` before writing CSV files so that the directory is created on first run, avoiding an error when the configured CSV path doesn't exist yet (e.g. https://github.com/0xB10C/mainnet-observer/pull/109#issuecomment-3968074247)

