### PR TITLE
fix(backend): add retry logic for block fetching (with hard fail)

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -13,9 +13,14 @@ use stats::Stats;
 use std::collections::BTreeSet;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use std::{error, fmt, io, thread};
 
 const DATABASE_BATCH_SIZE: usize = 100;
+
+// Retry configuration for block fetching
+const MAX_RETRY_ATTEMPTS: u32 = 5;
+const INITIAL_RETRY_DELAY_MS: u64 = 500;
 
 // Don't fetch (and process) the most recent blocks to be safe
 // in-case of a reorg.
@@ -209,10 +214,36 @@ pub fn collect_statistics(
             heights_to_fetch.par_iter()
                 .map(|&height| {
                     debug!("get-blocks: getting block at height {}", height);
-                    let block = match client.block_at_height(height as u64) {
-                        Ok(block) => block,
-                        Err(e) => {
-                            error!("Could not get block at height {}: {}", height, e);
+
+                    // Retry loop with exponential backoff
+                    let mut last_error = None;
+                    let block = (1..=MAX_RETRY_ATTEMPTS).find_map(|attempt| {
+                        match client.block_at_height(height as u64) {
+                            Ok(block) => Some(block),
+                            Err(e) => {
+                                if attempt < MAX_RETRY_ATTEMPTS {
+                                    let delay = INITIAL_RETRY_DELAY_MS
+                                        * 2u64.saturating_pow(attempt.saturating_sub(1));
+                                    warn!(
+                                        "Could not get block at height {} (attempt {}/{}): {}. Retrying in {}ms...",
+                                        height, attempt, MAX_RETRY_ATTEMPTS, e, delay
+                                    );
+                                    thread::sleep(Duration::from_millis(delay));
+                                }
+                                last_error = Some(e);
+                                None
+                            }
+                        }
+                    });
+
+                    let block = match block {
+                        Some(b) => b,
+                        None => {
+                            let e = last_error.unwrap();
+                            error!(
+                                "Failed to get block at height {} after {} attempts: {}",
+                                height, MAX_RETRY_ATTEMPTS, e
+                            );
                             return Err(MainError::REST(e));
                         }
                     };

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -11,6 +11,7 @@ use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 use stats::Stats;
 use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -210,14 +211,23 @@ pub fn collect_statistics(
             .num_threads(num_threads)
             .build()
             .unwrap();
+        let cancel = AtomicBool::new(false);
         pool.install(|| {
             heights_to_fetch.par_iter()
-                .map(|&height| {
+                .try_for_each(|&height| {
+                    // Fast exit if another thread already failed
+                    if cancel.load(Ordering::Relaxed) {
+                        return Ok(());
+                    }
+
                     debug!("get-blocks: getting block at height {}", height);
 
                     // Retry loop with exponential backoff
                     let mut last_error = None;
                     let block = (1..=MAX_RETRY_ATTEMPTS).find_map(|attempt| {
+                        if cancel.load(Ordering::Relaxed) {
+                            return None;
+                        }
                         match client.block_at_height(height as u64) {
                             Ok(block) => Some(block),
                             Err(e) => {
@@ -239,11 +249,16 @@ pub fn collect_statistics(
                     let block = match block {
                         Some(b) => b,
                         None => {
+                            // Cancelled by another thread's failure
+                            if cancel.load(Ordering::Relaxed) {
+                                return Ok(());
+                            }
                             let e = last_error.unwrap();
                             error!(
                                 "Failed to get block at height {} after {} attempts: {}",
                                 height, MAX_RETRY_ATTEMPTS, e
                             );
+                            cancel.store(true, Ordering::Relaxed);
                             return Err(MainError::REST(e));
                         }
                     };
@@ -252,15 +267,14 @@ pub fn collect_statistics(
                             "during sending block at height {} to stats generator: block receiver dropped",
                             height
                         );
-                        // We can return OK here. When the receiver is dropped, there
-                        // probably was an error in the calc-stats task.
+                        // When the receiver is dropped, there was probably an error
+                        // in the calc-stats task. Stop fetching blocks.
+                        cancel.store(true, Ordering::Relaxed);
                         return Ok(());
                     }
                     Ok(())
                 })
-                .for_each(drop); // Drop the result of the map (since it's already handled)
-        });
-        Ok(())
+        })
     });
 
     // calc-stats task

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -369,17 +369,21 @@ pub fn collect_statistics(
         Ok(())
     });
 
-    get_blocks_task
+    // Join all tasks before returning, even if one errored, to avoid
+    // leaving detached threads with in-flight DB writes.
+    let get_blocks_result = get_blocks_task
         .join()
-        .expect("The get-blocks task thread panicked")?;
-    calc_stats_task
+        .expect("The get-blocks task thread panicked");
+    let calc_stats_result = calc_stats_task
         .join()
-        .expect("The calc-stats task thread panicked")?;
-    batch_insert_task
+        .expect("The calc-stats task thread panicked");
+    let batch_insert_result = batch_insert_task
         .join()
-        .expect("The batch-insert task thread panicked")?;
+        .expect("The batch-insert task thread panicked");
 
-    Ok(())
+    get_blocks_result?;
+    calc_stats_result?;
+    batch_insert_result
 }
 
 pub fn write_csv_files(

--- a/backend/tests/minimal.rs
+++ b/backend/tests/minimal.rs
@@ -5,13 +5,18 @@ use mainnet_observer_backend::{collect_statistics, db, write_csv_files, REORG_SA
 use rand::distr::{Alphanumeric, SampleString};
 use std::env;
 use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 fn init_logger() {
-    env_logger::Builder::new()
+    let _ = env_logger::Builder::new()
         .filter_level(log::LevelFilter::Debug)
         .is_test(true)
-        .init();
+        .try_init();
 }
 
 fn setup_node() -> corepc_node::Node {
@@ -74,6 +79,98 @@ fn setup_db() -> Arc<Mutex<SqliteConnection>> {
     Arc::new(Mutex::new(conn))
 }
 
+struct MockRestServer {
+    host: String,
+    port: u16,
+    keep_running: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MockRestServer {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock rest listener");
+        listener
+            .set_nonblocking(true)
+            .expect("set listener nonblocking");
+        let port = listener.local_addr().expect("read local addr").port();
+        let keep_running = Arc::new(AtomicBool::new(true));
+        let keep_running_thread = Arc::clone(&keep_running);
+
+        let handle = thread::spawn(move || {
+            while keep_running_thread.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _addr)) => handle_connection(&mut stream),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_e) => break,
+                }
+            }
+        });
+
+        Self {
+            host: "127.0.0.1".to_string(),
+            port,
+            keep_running,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for MockRestServer {
+    fn drop(&mut self) {
+        self.keep_running.store(false, Ordering::Relaxed);
+        let _ = TcpStream::connect((self.host.as_str(), self.port));
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn handle_connection(stream: &mut TcpStream) {
+    let mut buffer = [0u8; 4096];
+    let bytes_read = match stream.read(&mut buffer) {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+    if bytes_read == 0 {
+        return;
+    }
+    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("/");
+
+    let (status, body, content_type) = if path == "/rest/chaininfo.json" {
+        (
+            "200 OK",
+            r#"{"initialblockdownload":false,"verificationprogress":1.0,"blocks":8}"#,
+            "application/json",
+        )
+    } else if path.starts_with("/rest/blockhashbyheight/") {
+        (
+            "500 Internal Server Error",
+            r#"{"error":"forced failure"}"#,
+            "application/json",
+        )
+    } else {
+        (
+            "404 Not Found",
+            r#"{"error":"not found"}"#,
+            "application/json",
+        )
+    };
+
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
 #[test]
 fn test_integration_minimal() {
     const BLOCKS_TO_MINE: i64 = 100;
@@ -123,4 +220,23 @@ fn test_integration_minimal() {
     // cleanup
     fs::remove_dir_all(&dir).unwrap();
     assert!(!failed);
+}
+
+#[test]
+fn test_collect_statistics_fails_on_block_fetch_retry_exhaustion() {
+    init_logger();
+    let conn = setup_db();
+    let mock = MockRestServer::start();
+
+    let result = collect_statistics(&mock.host, mock.port, Arc::clone(&conn), 2, None);
+
+    match result {
+        Err(mainnet_observer_backend::MainError::REST(e)) => {
+            assert!(
+                e.to_string().contains("HTTP error: 500"),
+                "expected HTTP 500 from mock REST server, got: {e}"
+            );
+        }
+        other => panic!("expected HTTP REST error after retry exhaustion, got: {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary

The block-fetching pipeline in `collect_statistics()` discards errors from rayon workers. When a thread fails to fetch a block (e.g. HTTP 500, network timeout), the `Err` is consumed by `.map(...).for_each(drop)` and the process continues, exiting 0 regardless of how many blocks failed.

If Bitcoin Core is completely down, every fetch fails and the database gets zero new rows. The logs are noisy with errors so an attentive user would notice, but the exit code is 0 (however, any automation checking exit status would report success). The more insidious case is partial failure, where some blocks succeed and others silently don't. The database advances, charts update, everything looks healthy except that there are gaps in the data. And without retry logic, even a momentary network blip or Bitcoin Core being briefly overloaded (I've experienced this a few times in the past, the initial motivation for the retry functionality) causes data loss that can only be recovered by a re-run.

This PR addresses all three concerns:

**Retry with exponential backoff** (500ms, 1s, 2s, 4s - up to 5 attempts by default) handles transient failures automatically, so a brief network hiccup or a slow Core response doesn't require operator intervention.

**`try_for_each` with `AtomicBool` cancel flag** replaces `.for_each(drop)` so that when retries are exhausted, the error propagates and the process exits non-zero. Already-running threads check the cancel flag at three points (top of closure, inside retry loop, after retry exhaustion) and bail out early rather than doing unnecessary work.

**Unconditional thread join** fixes the shutdown sequence. Previously, the `?` operator on each `.join()` meant that if the first task errored, the other two threads would be left detached with potentially in-flight database writes. Now all three tasks are joined before checking any results, ensuring clean shutdown regardless of which task fails.

## Visualisations

Let's see if visualisations help illustrate the problem and fix (personally I find visualising problems and fixes easier than just reading code...)

**The Bug (upstream master)**:`.for_each(drop)` silently discards errors across three failure scenarios:

<img width="1745" height="709" alt="1 - The Bug (Master)" src="https://github.com/user-attachments/assets/1b8bc3d3-cd25-444d-8a74-3de7c58d6051" />

**The Fix**: retry with exponential backoff, `try_for_each` error propagation, and unconditional thread join:

<img width="1745" height="899" alt="2 - The Fix" src="https://github.com/user-attachments/assets/fb3057b4-9ea6-4f6e-90f6-7daea94c7bb2" />

## Testing

A new integration test (`test_collect_statistics_fails_on_block_fetch_retry_exhaustion`) uses a mock REST server that returns `chaininfo` successfully but responds with HTTP 500 to all block hash requests. This exercises the full retry-exhaustion path: the pipeline makes up to 5 attempts with backoff, gives up, sets the cancel flag, and propagates a `MainError::REST` error. The test asserts both the error variant and that the underlying message contains "HTTP error: 500".

Manual testing was done against three failure scenarios with logging enabled (as alluded to in the visualisations), happy to provide further details if necessary!!