### PR TITLE
add --start-height <block height> flag to backend, this is useful for testing database changes without doing a full sync

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
             args.rest_port,
             Arc::clone(&conn),
             args.num_threads,
+            args.start_height,
         ) {
             error!("Could not collect statistics: {}", e);
             exit(1);

--- a/backend/tests/minimal.rs
+++ b/backend/tests/minimal.rs
@@ -90,6 +90,7 @@ fn test_integration_minimal() {
         rest_port,
         Arc::clone(&conn),
         10, // Bitcoin Core v29 has 16, in the test use just use 10 of them.
+        None,
     ) {
         panic!("Failed to collect statistics: {:?}", e);
     }


### PR DESCRIPTION
As discussed in https://github.com/0xB10C/mainnet-observer/issues/31#issuecomment-3972531179