### PR TITLE
fix(input_stats): insert_into missed replace_into conversion

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -561,7 +561,7 @@ fn insert_input_stats(
     use crate::schema::input_stats;
     debug!("Inserting a batch of {} input stats", stats.len());
 
-    diesel::insert_into(input_stats::table)
+    diesel::replace_into(input_stats::table)
         .values(stats)
         .execute(conn)?;
     Ok(())


### PR DESCRIPTION
## Summary

`insert_input_stats` uses `diesel::insert_into` while the other five stats insert functions all use `diesel::replace_into`. On a rescan (e.g. triggered by bumping `STATS_VERSION`), existing heights are re-inserted: the `replace_into` tables handle this fine by overwriting, but `input_stats` crashes with a `UNIQUE constraint failed` error on the first duplicate height encountered.

| Function | Operation |
|---|---|
| `insert_block_stats` | `diesel::replace_into` |
| `insert_tx_stats` | `diesel::replace_into` |
| **`insert_input_stats`** | **`diesel::insert_into`** |
| `insert_output_stats` | `diesel::replace_into` |
| `insert_script_stats` | `diesel::replace_into` |
| `insert_feerate_stats` | `diesel::replace_into` |

This inconsistency was introduced in https://github.com/0xB10C/mainnet-observer/commit/f96790b2524f100d532a74d616f8ce7784f1f332 ("change: use replace_into instead of insert_into"), which converted all six functions from `insert_into`-with-upsert-fallback to simple `replace_into`, but missed `input_stats` (leaving it as bare `insert_into` without the fallback). Prior to that commit, `insert_input_stats` had the same `on_conflict().do_update()` fallback as the others, so UNIQUE violations were handled (albeit slowly and with the noted memory leak).

The fix is a one-line change: `diesel::insert_into(input_stats::table)` → `diesel::replace_into(input_stats::table)`.

## Testing

Calling `insert_input_stats` twice for the same height should not crash:

```rust
#[cfg(test)]
mod tests {
    use super::*;

    #[test]
    fn test_insert_input_stats_rescan_duplicate_height() {
        let mut conn = open_db_and_run_migrations(":memory:").unwrap();
        let stats = vec![InputStats::default()];

        insert_input_stats(&mut conn, &stats).expect("first insert should succeed");

        // Second insert at the same height - simulates rescan.
        insert_input_stats(&mut conn, &stats)
            .expect("rescan insert should succeed with replace_into");
    }
}
```

On master:

```
running 1 test
thread 'db::tests::test_insert_input_stats_rescan_duplicate_height' (8460179) panicked at src/db.rs:627:14:
rescan insert should succeed with replace_into: DatabaseError(UniqueViolation, "UNIQUE constraint failed:
input_stats.height")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test db::tests::test_insert_input_stats_rescan_duplicate_height ... FAILED

failures:

failures:
    db::tests::test_insert_input_stats_rescan_duplicate_height

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.01s
```

With fix:

```
running 1 test
test db::tests::test_insert_input_stats_rescan_duplicate_height ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.01s
```

## Note

`STATS_VERSION` has since been bumped twice:
- `2` in `49918a9` (coinbase locktime stats)
- `3` in `bccc91c` (coinbase output stats). 

The first bump (`1` → `2`) landed before `f96790b`, so that rescan still had the old upsert fallback and would have completed. 

But the second bump (`2` → `3`) landed after `f96790b`, meaning that rescan would hit a bare `insert_into` on `input_stats` with no fallback, so should have crashed on the first duplicate height???