### PR TITLE
transactions-height-based-locktime: Add Bitcoin Core v0.11.0 annotation

### DIFF
--- a/frontend/static/js/charts/transactions-height-based-locktime.js
+++ b/frontend/static/js/charts/transactions-height-based-locktime.js
@@ -2,8 +2,7 @@ const ANNOTATIONS = [annotationBitcoinCorev0_11_0]
 const MOVING_AVERAGE_DAYS = MOVING_AVERAGE_7D
 const NAME = "lock-by-block-height"
 const PRECISION = 2
-let START_DATE =  new Date();
-START_DATE.setFullYear(new Date().getFullYear() - 5);
+let START_DATE = new Date("2014");
 
 const CSVs = [
   fetchCSV("/csv/date.csv"),

--- a/frontend/static/js/charts/transactions-height-based-locktime.js
+++ b/frontend/static/js/charts/transactions-height-based-locktime.js
@@ -1,4 +1,4 @@
-const ANNOTATIONS = []
+const ANNOTATIONS = [annotationBitcoinCorev0_11_0]
 const MOVING_AVERAGE_DAYS = MOVING_AVERAGE_7D
 const NAME = "lock-by-block-height"
 const PRECISION = 2

--- a/frontend/static/js/lib.js
+++ b/frontend/static/js/lib.js
@@ -13,6 +13,7 @@ const annotationBitcoinQTv0_8 = {'text': 'Bitcoin-QT v0.8 release', 'date': '201
 const annotationBitcoinCorev0_9 = {'text': 'Bitcoin Core v0.9.0 release', 'date': '2014-03-19'}
 const annotationBitcoinCorev0_10 = {'text': 'Bitcoin Core v0.10.0 release', 'date': '2015-02-16'}
 const annotationBIP66Activated = {'text': 'BIP66 Activation', 'date': '2015-07-04'}
+const annotationBitcoinCorev0_11_0 = {'text': 'Bitcoin Core v0.11.0 released with anti-fee-sniping', 'date': '2015-07-10'}
 const annotationBitcoinCorev0_11_1 = {'text': 'Bitcoin Core v0.11.1 release', 'date': '2015-10-15'}
 const annotationBitcoinCoreSegWitWalletReleased = {'text': 'Bitcoin Core SegWit wallet released', 'date': '2018-02-26'}
 const annotationSegWitActivated = {'text': 'SegWit Activation', 'date': '2017-08-24'}


### PR DESCRIPTION
anti-fee-sniping uses height-based locktime, and IIRC the first impl was https://github.com/bitcoin/bitcoin/blob/58dccd27e11de68f810145fc30631a2c446f3bf5/doc/release-notes/release-notes-0.11.0.md#wallet in https://github.com/bitcoin/bitcoin/releases/tag/v0.11.0 with commit https://github.com/bitcoin/bitcoin/commit/ba7fcc8de06602576ab6a5911879d3d8df80d36a.

So I guess it can't hurt to add an annotation.

