### PR TITLE
hugo: Fix two deprecation warnings

### DIFF
--- a/frontend/config.toml
+++ b/frontend/config.toml
@@ -4,7 +4,7 @@ title = "PLACEHOLDER-TITLE"
 # Can also be controlled with the HUGO_BASEURL env var.
 # FIXME: (unless set via the ENV var)
 baseURL = "https://placeholder.example.com"
-languageCode = "en-us"
+locale = "en-us"
 
 relativeURLs = true
 disableHugoGeneratorInject = false

--- a/frontend/layouts/charts/single.html
+++ b/frontend/layouts/charts/single.html
@@ -45,7 +45,7 @@
 {{- define "js" -}}
 <script>
   const chartPNGFileName = "{{ .Page.File.TranslationBaseName }}";
-  const isDevBuild = {{ if .Site.BuildDrafts }} true {{ else }} false {{ end }};
+  const isDevBuild = {{ hugo.IsDevelopment }};
   const watermarkText = "{{ .Site.Title }}"
 </script>
 

--- a/frontend/layouts/index.html
+++ b/frontend/layouts/index.html
@@ -31,7 +31,7 @@
         {{end}} {{end}}
     </section>
 
-    {{ if .Site.BuildDrafts }}
+    {{ if hugo.IsDevelopment }}
     <script>
         chartURLs = [
         {{- range where .Site.RegularPages "Section" "charts" -}}


### PR DESCRIPTION
Fixes the two deprecation warnings from https://github.com/0xB10C/mainnet-observer/actions/runs/24235975443/job/70758531105?pr=155#step:4:5:

```
INFO  deprecated: project config key languageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use locale instead.

WARN  deprecated: .Site.BuildDrafts was deprecated in Hugo v0.156.0 and will be removed in a future release. See https://discourse.gohugo.io/t/56732.
```

