### PR TITLE
fix: hide hidden charts from search results

### DIFF
--- a/frontend/layouts/_default/index.json
+++ b/frontend/layouts/_default/index.json
@@ -2,7 +2,10 @@
 
 {{- range .Site.RegularPages -}}
 
-  {{- if not .Draft -}}
+  {{- $isChart := eq .Section "charts" -}}
+  {{- $isHidden := or (eq .Params.categories "Hidden") (eq .Params.categories "dev-only") -}}
+
+  {{- if and $isChart (not .Draft) (not $isHidden) -}}
 
     {{- $.Scratch.Add "index"
     (


### PR DESCRIPTION
Fixes #154. Previously, the search would have shown hidden charts in the search. For eaxmple, the catch-all chart for an older chart missing. No need to show these in the search results.