### PR TITLE
add: increase default DB batch size 100 ->1000 and make it configurable

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{error, fmt, io, thread};
 
-const DATABASE_BATCH_SIZE: usize = 100;
+const DEFAULT_DATABASE_BATCH_SIZE: usize = 1000;
 
 // Retry configuration for block fetching
 const MAX_RETRY_ATTEMPTS: u32 = 5;
@@ -139,6 +139,10 @@ pub struct Args {
     /// Useful for testing database or stats changes without doing a full sync.
     #[arg(long)]
     pub start_height: Option<u64>,
+
+    /// Number of block stats to batch together before writing to the database.
+    #[arg(long, default_value_t = DEFAULT_DATABASE_BATCH_SIZE)]
+    pub database_batch_size: usize,
 }
 
 pub fn collect_statistics(
@@ -147,6 +151,7 @@ pub fn collect_statistics(
     connection: Arc<Mutex<SqliteConnection>>,
     num_threads: usize,
     start_height: Option<u64>,
+    database_batch_size: usize,
 ) -> Result<(), MainError> {
     let connection = Arc::clone(&connection);
 
@@ -322,7 +327,7 @@ pub fn collect_statistics(
         let connection = Arc::clone(&connection);
         let mut conn = connection.lock().unwrap();
         db::performance_tune(&mut conn)?;
-        let mut stat_buffer = Vec::with_capacity(DATABASE_BATCH_SIZE);
+        let mut stat_buffer = Vec::with_capacity(database_batch_size);
         let mut written = 0;
 
         loop {
@@ -342,7 +347,7 @@ pub fn collect_statistics(
             };
 
             stat_buffer.push(stat);
-            if stat_buffer.len() >= DATABASE_BATCH_SIZE {
+            if stat_buffer.len() >= database_batch_size {
                 db::insert_stats(&mut conn, &stat_buffer)?;
                 written += stat_buffer.len();
                 info!(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
             Arc::clone(&conn),
             args.num_threads,
             args.start_height,
+            args.database_batch_size,
         ) {
             error!("Could not collect statistics: {}", e);
             exit(1);

--- a/backend/tests/minimal.rs
+++ b/backend/tests/minimal.rs
@@ -188,6 +188,7 @@ fn test_integration_minimal() {
         Arc::clone(&conn),
         10, // Bitcoin Core v29 has 16, in the test use just use 10 of them.
         None,
+        1000,
     ) {
         panic!("Failed to collect statistics: {:?}", e);
     }
@@ -228,7 +229,7 @@ fn test_collect_statistics_fails_on_block_fetch_retry_exhaustion() {
     let conn = setup_db();
     let mock = MockRestServer::start();
 
-    let result = collect_statistics(&mock.host, mock.port, Arc::clone(&conn), 2, None);
+    let result = collect_statistics(&mock.host, mock.port, Arc::clone(&conn), 2, None, 1000);
 
     match result {
         Err(mainnet_observer_backend::MainError::REST(e)) => {


### PR DESCRIPTION
The DB batch size controls how many blocks worth of data we keep in memory before writing to the database. Keeping more blocks in memory means higher memory usage, but less frequent writes to disk. This might improve performance on some systems.