### PR TITLE
fix: clippy warning about into_iter()

### DIFF
--- a/backend/src/stats.rs
+++ b/backend/src/stats.rs
@@ -480,8 +480,7 @@ impl TxStats {
                 // A transaction with more than 1 dust output was likely submitted out-of-band, so don't count them in
                 // the `tx_spending_ephemeral_dust` tally
                 if staged_ephemeral_dust_outpoints.len() == 1 {
-                    ephemeral_dust_outpoints_in_this_block
-                        .extend(staged_ephemeral_dust_outpoints.into_iter());
+                    ephemeral_dust_outpoints_in_this_block.extend(staged_ephemeral_dust_outpoints);
                 }
             }
 


### PR DESCRIPTION
While this didn't warn for me locally (likely an older version of clippy installed) it warned and failed CI in https://github.com/0xB10C/mainnet-observer/pull/170#issuecomment-4508219446

```
error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> src/stats.rs:484:33
    |
484 |                         .extend(staged_ephemeral_dust_outpoints.into_iter());
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/iter/traits/collect.rs:416:17
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#useless_conversion
    = note: `-D clippy::useless-conversion` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`
help: consider removing the `.into_iter()`
    |
484 -                         .extend(staged_ephemeral_dust_outpoints.into_iter());
484 +                         .extend(staged_ephemeral_dust_outpoints);
    |

```