### PR TITLE
update: chart BIP-54 Coinbase Locktime set tags

### DIFF
--- a/frontend/content/charts/transactions-coinbase-locktime-bip54.md
+++ b/frontend/content/charts/transactions-coinbase-locktime-bip54.md
@@ -4,7 +4,7 @@ draft: false
 author: "0xb10c"
 categories: Transactions
 categories_weight: 0
-tags: [coinbase, locktime bip54]
+tags: [coinbase, locktime, bip54]
 thumbnail: transactions-coinbase-locktime-bip54.png
 chartJS: transactions-coinbase-locktime-bip54.js
 images:


### PR DESCRIPTION
The tags for the 'BIP-54 Coinbase Locktime set' chart were missing a separator. 